### PR TITLE
Add golden tests that illustrate parsing results

### DIFF
--- a/hs/eexpr-bindings/eexpr-bindings.cabal
+++ b/hs/eexpr-bindings/eexpr-bindings.cabal
@@ -72,16 +72,18 @@ executable eexpr-delme
   default-language: Haskell2010
   ghc-options: -Wall -O2 -threaded
 
--- test-suite test
---   hs-source-dirs: test
---   main-is: Main.hs
---   type: exitcode-stdio-1.0
---   build-depends:
---     , eexpr-bindings
---     , base
---     -- , quickcheck-classes
---     -- , tasty
---     -- , tasty-hunit
---     -- , tasty-quickcheck
---   default-language: Haskell2010
---   ghc-options: -Wall -O2
+test-suite test
+  ghc-options: -Wall -O2 -threaded
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Main.hs
+  build-depends:
+    , base
+    , eexpr-core
+    , eexpr-bindings
+    , tasty-golden
+    , tasty >=1.4.2
+    , pretty-show >=1.10
+    , bytestring
+    , text

--- a/hs/eexpr-bindings/sample/001/input.txt
+++ b/hs/eexpr-bindings/sample/001/input.txt
@@ -1,0 +1,3 @@
+do:
+  years = dog.age + 55
+  print("The dog is `years` years old!")

--- a/hs/eexpr-bindings/sample/001/output/location.txt
+++ b/hs/eexpr-bindings/sample/001/output/location.txt
@@ -1,0 +1,105 @@
+[ Space
+    Location
+      { start = LocPoint { byteOff = 0 , lineOff = 0 , colOff = 0 }
+      , end = LocPoint { byteOff = 68 , lineOff = 3 , colOff = 0 }
+      }
+    (Symbol
+       Location
+         { start = LocPoint { byteOff = 0 , lineOff = 0 , colOff = 0 }
+         , end = LocPoint { byteOff = 2 , lineOff = 0 , colOff = 2 }
+         }
+       "do" :||
+       (Block
+          Location
+            { start = LocPoint { byteOff = 0 , lineOff = 1 , colOff = 0 }
+            , end = LocPoint { byteOff = 68 , lineOff = 3 , colOff = 0 }
+            }
+          (Space
+             Location
+               { start = LocPoint { byteOff = 6 , lineOff = 1 , colOff = 2 }
+               , end = LocPoint { byteOff = 26 , lineOff = 1 , colOff = 22 }
+               }
+             (Symbol
+                Location
+                  { start = LocPoint { byteOff = 6 , lineOff = 1 , colOff = 2 }
+                  , end = LocPoint { byteOff = 11 , lineOff = 1 , colOff = 7 }
+                  }
+                "years" :||
+                (Symbol
+                   Location
+                     { start = LocPoint { byteOff = 12 , lineOff = 1 , colOff = 8 }
+                     , end = LocPoint { byteOff = 13 , lineOff = 1 , colOff = 9 }
+                     }
+                   "=" :|
+                   [ Chain
+                       Location
+                         { start = LocPoint { byteOff = 14 , lineOff = 1 , colOff = 10 }
+                         , end = LocPoint { byteOff = 21 , lineOff = 1 , colOff = 17 }
+                         }
+                       (Symbol
+                          Location
+                            { start = LocPoint { byteOff = 14 , lineOff = 1 , colOff = 10 }
+                            , end = LocPoint { byteOff = 17 , lineOff = 1 , colOff = 13 }
+                            }
+                          "dog" :||
+                          (Symbol
+                             Location
+                               { start = LocPoint { byteOff = 18 , lineOff = 1 , colOff = 14 }
+                               , end = LocPoint { byteOff = 21 , lineOff = 1 , colOff = 17 }
+                               }
+                             "age" :|
+                             []))
+                   , Symbol
+                       Location
+                         { start = LocPoint { byteOff = 22 , lineOff = 1 , colOff = 18 }
+                         , end = LocPoint { byteOff = 23 , lineOff = 1 , colOff = 19 }
+                         }
+                       "+"
+                   , Number
+                       Location
+                         { start = LocPoint { byteOff = 24 , lineOff = 1 , colOff = 20 }
+                         , end = LocPoint { byteOff = 26 , lineOff = 1 , colOff = 22 }
+                         }
+                       Bignum
+                         { significand = 55
+                         , radix = Radix 10
+                         , fractionalExponent = 0
+                         , explicitExponent = 0
+                         }
+                   ])) :|
+             [ Chain
+                 Location
+                   { start = LocPoint { byteOff = 29 , lineOff = 2 , colOff = 2 }
+                   , end = LocPoint { byteOff = 67 , lineOff = 2 , colOff = 40 }
+                   }
+                 (Symbol
+                    Location
+                      { start = LocPoint { byteOff = 29 , lineOff = 2 , colOff = 2 }
+                      , end = LocPoint { byteOff = 34 , lineOff = 2 , colOff = 7 }
+                      }
+                    "print" :||
+                    (Paren
+                       Location
+                         { start = LocPoint { byteOff = 34 , lineOff = 2 , colOff = 7 }
+                         , end = LocPoint { byteOff = 67 , lineOff = 2 , colOff = 40 }
+                         }
+                       (Just
+                          (String
+                             Location
+                               { start = LocPoint { byteOff = 35 , lineOff = 2 , colOff = 8 }
+                               , end = LocPoint { byteOff = 66 , lineOff = 2 , colOff = 39 }
+                               }
+                             "The dog is "
+                             [ ( Symbol
+                                   Location
+                                     { start = LocPoint { byteOff = 48 , lineOff = 2 , colOff = 21 }
+                                     , end = LocPoint { byteOff = 53 , lineOff = 2 , colOff = 26 }
+                                     }
+                                   "years"
+                               , " years old!"
+                               )
+                             ])) :|
+                       []))
+             ]) :|
+          []))
+]

--- a/hs/eexpr-bindings/sample/001/output/plain.txt
+++ b/hs/eexpr-bindings/sample/001/output/plain.txt
@@ -1,0 +1,32 @@
+[ Space
+    ()
+    (Symbol () "do" :||
+       (Block
+          ()
+          (Space
+             ()
+             (Symbol () "years" :||
+                (Symbol () "=" :|
+                   [ Chain () (Symbol () "dog" :|| (Symbol () "age" :| []))
+                   , Symbol () "+"
+                   , Number
+                       ()
+                       Bignum
+                         { significand = 55
+                         , radix = Radix 10
+                         , fractionalExponent = 0
+                         , explicitExponent = 0
+                         }
+                   ])) :|
+             [ Chain
+                 ()
+                 (Symbol () "print" :||
+                    (Paren
+                       ()
+                       (Just
+                          (String
+                             () "The dog is " [ ( Symbol () "years" , " years old!" ) ])) :|
+                       []))
+             ]) :|
+          []))
+]

--- a/hs/eexpr-bindings/test/Main.hs
+++ b/hs/eexpr-bindings/test/Main.hs
@@ -1,0 +1,48 @@
+{-# language BangPatterns #-}
+
+import Data.Eexpr.Text (parse)
+import Data.Eexpr.Types (Eexpr,Location)
+import Data.Text.Encoding (encodeUtf8)
+import Test.Tasty (defaultMain,testGroup)
+import Test.Tasty.Golden (goldenVsString)
+import Text.Show.Pretty (ppShow)
+
+import qualified Data.Text as T
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as LB
+
+main :: IO ()
+main = defaultMain $ testGroup "sample"
+  [ goldenVsString "001" "sample/001/output/location.txt" (loadExprLocation "sample/001/input.txt")
+  , goldenVsString "001" "sample/001/output/plain.txt" (loadExprPlain "sample/001/input.txt")
+  ]
+
+loadExprPlain :: String -> IO LB.ByteString
+loadExprPlain filename = do
+  e <- loadExpr filename
+  let !b = encodeUtf8 (T.pack (ppShow ((fmap.fmap) (\_ -> ()) e)))
+  pure (LB.fromStrict b)
+
+loadExprLocation :: String -> IO LB.ByteString
+loadExprLocation filename = do
+  e <- loadExpr filename
+  let !b = encodeUtf8 (T.pack (ppShow e))
+  pure (LB.fromStrict b)
+
+loadExpr :: String -> IO [Eexpr Location]
+loadExpr filename = do
+  contents <- B.readFile filename
+  let (warnings, e) = parse contents
+  case e of
+    Left errors -> do
+      fail $ concat $
+        [ "Failed to parse.\nWarnings:\n" ]
+        ++ map (\x -> show x ++ "\n") warnings
+        ++ [ "Errors:\n" ]
+        ++ map (\x -> show x ++ "\n") errors
+    Right r -> case warnings of
+      [] -> pure r
+      _ -> fail $ concat $
+        [ "Parsed successfully but encountered warnings:\n" ]
+        ++ map (\x -> show x ++ "\n") warnings
+    

--- a/hs/eexpr-core/src/Data/Eexpr/Types.hs
+++ b/hs/eexpr-core/src/Data/Eexpr/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE PatternSynonyms #-}
 
@@ -37,7 +38,7 @@ data Eexpr ann
   | Comma     ann [Eexpr ann]
   | Semicolon ann [Eexpr ann]
   deriving stock (Read, Show)
-  deriving stock (Eq)
+  deriving stock (Eq,Functor)
 
 mapAnnotation :: (a -> b) -> Eexpr a -> Eexpr b
 mapAnnotation f (Symbol a x) = Symbol (f a) x


### PR DESCRIPTION
This adds a simple integration test that serves two purposes:

1. Illustrate the ASTs resulting from parsing simple expressions. A combination of `pretty-show` and dropping all location annotations results in output that is at least somewhat readable. It would be better to manually write a pretty printer for the expression type, but that's more difficult to do.
2. Confirm that the parser works as expected.

Concerning goal (2), I have a concern. I'm trying to use a string template in the input file, but the parser does not seem to understand what I've done:

             [ Chain
                 ()
                 (Symbol () "print" :||
                    (Paren () (Just (String () "The dog is `years` years old!" [])) :|
                       []))
             ]) :|

I expected that `years` would be broken apart from the other stuff, but I might just be using string templates incorrectly.